### PR TITLE
change g++'s parameters's order to allow linking for newest versions of g++

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -190,11 +190,12 @@
 			<arg value="-I${sfml.include}" />
 			<arg value="-I${env.JAVA_HOME}/include" />
 			<arg value="-I${env.JAVA_HOME}/include/linux" />
+			<arg value="-L${sfml.bin}/${arch}" />
 			<arg value="-shared" />
 			<arg value="-fPIC" />
 			<arg value="-o${cpp.out}/${arch}/lib${jsfml.bin}.so" />
 			<arg line="${cpp.src.files}" />
-			<arg value="-Wl,-no-undefined,-L${sfml.bin}/${arch},-lsfml-audio,-lsfml-graphics,-lsfml-window,-lsfml-system" />
+			<arg value="-Wl,-no-undefined,-lsfml-audio,-lsfml-graphics,-lsfml-window,-lsfml-system" />
 		</exec>
 
 		<copy todir="${cpp.out}/${arch}">


### PR DESCRIPTION
Seems that in newest g++ the order of parameters is different...

I hope to be helpful
